### PR TITLE
fix: temporarily remove tailwind typography from project details page [c198_5b7a_0012-T0-286]

### DIFF
--- a/src/app/projects/[slug]/page.tsx
+++ b/src/app/projects/[slug]/page.tsx
@@ -13,7 +13,7 @@ const page = async ({ params }: { params: { slug: string } }) => {
 	return (
 		<div className='px-16 mt-8'>
 			<h1 className='text-lg text-center font-semibold'>{engPost?.title}</h1>
-			<div className='mx-auto prose sm:max-w-md md:max-w-xl lg:max-w-none'>
+			<div className='mx-auto sm:max-w-md md:max-w-xl lg:max-w-none'>
 				<div>Published Date: {engPost?.publishedDate}</div>
 				<RichText document={engPost?.content} />
 			</div>


### PR DESCRIPTION
Temporarily removed [@tailwindcss/typography](https://tailwindcss.com/docs/typography-plugin) plugin. The plugin was conflicting with Material UI, and causing font to be very illegible.

This fix is temporary.